### PR TITLE
add:breedモデル生成

### DIFF
--- a/app/models/breed.rb
+++ b/app/models/breed.rb
@@ -1,0 +1,6 @@
+class Breed < ApplicationRecord
+  validates :name, length: { maximum: 32 }, allow_blank: true
+
+  has_many :questions, dependent: :nullify
+  # dependent: :nullifyで、breedが削除されてもquestionは残り、breedにはnullが入る
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,4 +2,6 @@ class Question < ApplicationRecord
   validates :body, presence: true, length: { maximum: 65_535 }
   validates :nickname, length: { maximum: 32 }, allow_blank: true
   validates :age, numericality: { only_integer: true }, allow_blank: true
+
+  belongs_to :breed
 end

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -4,6 +4,8 @@
       <div class="justify-center items-center gap-y-8 p-5 m-5 bg-ivory text-brown">
         <p><%= question.nickname %></p>
         <p><%= question.age %>歳</p>
+        <p><%= question.breed&.name %></p>
+        <!-- &.で、question.breedがnilでない時のみnameを呼び出す -->
         <p><%= question.body %></p>
         <p><%= question.created_at %></p>
       </div>

--- a/db/migrate/20250615083422_create_breeds.rb
+++ b/db/migrate/20250615083422_create_breeds.rb
@@ -1,0 +1,9 @@
+class CreateBreeds < ActiveRecord::Migration[8.0]
+  def change
+    create_table :breeds do |t|
+      t.string :name, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250615084131_add_breed_to_questions.rb
+++ b/db/migrate/20250615084131_add_breed_to_questions.rb
@@ -1,0 +1,5 @@
+class AddBreedToQuestions < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :questions, :breed, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_15_022823) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_15_084131) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "breeds", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "questions", force: :cascade do |t|
     t.text "body", null: false
@@ -20,5 +26,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_15_022823) do
     t.integer "age"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "breed_id"
+    t.index ["breed_id"], name: "index_questions_on_breed_id"
   end
+
+  add_foreign_key "questions", "breeds"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,10 +8,22 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
+breeds =Breed.create!(
+    [
+      { name: "柴犬" },
+      { name: "トイプードル" },
+      { name: "スタンダードプードル" },
+      { name: "ラブラドール" },
+      { name: "ミックス" }
+    ]
+  )
+
 10.times do |i|
   Question.create!(
     nickname: "匿名#{i+1}さん",
     age: rand(7..17),
-    body: "シニア犬についての質問#{i+1}です。"
+    body: "シニア犬についての質問#{i+1}です。",
+    breed: breeds.sample
+    # breedをランダムで割り当てる
   )
 end

--- a/test/fixtures/breeds.yml
+++ b/test/fixtures/breeds.yml
@@ -1,0 +1,12 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  name: 柴犬
+# column: value
+#
+
+# column: value

--- a/test/models/breed_test.rb
+++ b/test/models/breed_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BreedTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
#60 にて作成したquestionsテーブルに含めていたbreedカラム（犬種）について、
管理するデータが多くなることが予想されるため、breedモデルとして切り出すこととしました。

ER図を下記の通り修正しました。
つぶやき(feelings)テーブルとの関連づけも必要ですが、
現時点では質問(questions)との関連のみ修正しています。

### 修正前
[![Image from Gyazo](https://i.gyazo.com/5885af9f7159d68619780e501ba5af16.png)](https://gyazo.com/5885af9f7159d68619780e501ba5af16)

### 修正後
[![Image from Gyazo](https://i.gyazo.com/2da4d09fc9824ccff58f803e94403c6f.png)](https://gyazo.com/2da4d09fc9824ccff58f803e94403c6f)

closes #62 