### PR TITLE
add:ゲストユーザーの識別を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,13 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  before_action :set_guest_id
+
+  private
+
+  def set_guest_id
+    # ||=で、すでに保存されていれば使う。なければ新しく作成して保存
+    cookies.permanent[:guest_id] ||= SecureRandom.uuid
+  end
 end

--- a/app/controllers/stamps_controller.rb
+++ b/app/controllers/stamps_controller.rb
@@ -2,7 +2,11 @@ class StampsController < ApplicationController
   before_action :set_stampable
   def create
     @stamp = @stampable.stamps.build(stamp_params)
-    # @stamp.user = current_user if current_user
+    # if current_user
+    # @stamp.user = current_user
+    # else
+    @stamp.guest_id = cookies[:guest_id]
+    # end
 
     if @stamp.save
       respond_to do |format|

--- a/db/migrate/20250711101933_add_guest_id_to_stamps.rb
+++ b/db/migrate/20250711101933_add_guest_id_to_stamps.rb
@@ -1,0 +1,5 @@
+class AddGuestIdToStamps < ActiveRecord::Migration[8.0]
+  def change
+    add_column :stamps, :guest_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_28_001242) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_11_101933) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -52,6 +52,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_28_001242) do
     t.bigint "stampable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "guest_id"
     t.index ["stamp_type_id"], name: "index_stamps_on_stamp_type_id"
     t.index ["stampable_type", "stampable_id"], name: "index_stamps_on_stampable"
     t.index ["user_id"], name: "index_stamps_on_user_id"


### PR DESCRIPTION
ゲストユーザーを識別できるようにしました。

- [x] ApplicationControllerに ``` set quest_id ``` を追加
- [x] Stampsテーブルにguest_idカラムを追加
- [x] StampsCntrollerに``` @stamp.guest_id = cookies[:guest_id] ```を追加
