### PR TITLE
fix:stamp_buttonsのパーシャルを編集

### DIFF
--- a/app/views/stamps/_stamp_buttons.html.erb
+++ b/app/views/stamps/_stamp_buttons.html.erb
@@ -1,12 +1,15 @@
 
 <!-- スタンプ表示ここから -->
 <div class="mt-4 flex gap-3">
-<% stamp_counts = question.stamps.group(:stamp_type_id).count %>
+  <% stamp_counts = question.stamps.group(:stamp_type_id).count %>
+  <% user_stamp_ids = question.stamps.where(guest_id: cookies[:guest_id]).pluck(:stamp_type_id) %>
+
   <% StampType.all.each do |stamp_type| %>
     <% count = stamp_counts[stamp_type.id] || 0 %>
-    <% existing = question.stamps.find_by(stamp_type: stamp_type) %>
+    <% user_pressed = user_stamp_ids.include?(stamp_type.id) %>
+    <% existing = question.stamps.find_by(stamp_type_id: stamp_type.id, guest_id: cookies[:guest_id]) %>
 
-    <% if existing %>
+    <% if user_pressed && existing %>
       <%= form_with url: question_stamp_path(question, existing),
                     method: :delete,
                     local: false,
@@ -29,4 +32,5 @@
     <% end %>
   <% end %>
 </div>
+
 <!-- スタンプ表示ここまで -->


### PR DESCRIPTION
stamp_buttonsのパーシャルを編集しました。

スタンプが押されているかどうかで条件分岐していた所を
スタンプが押されていてかつ自分が押したかどうかで条件分岐するようにしました。