### PR TITLE
fix:スタンプにユニークidを付与

### DIFF
--- a/app/views/question_answers/_question_answer.html.erb
+++ b/app/views/question_answers/_question_answer.html.erb
@@ -2,7 +2,5 @@
   <p class="text-sm text-gray-600"><%= question_answer.created_at.strftime('%Y/%m/%d') %></p>
   <p class="mt-2 text-brown"><%= question_answer.body %></p>
 
-  <div id="stamps_<%= "#{question_answer.id}" %>" >
-   <%= render partial: "stamps/stamp_buttons", locals: { stampable: question_answer, stamp_types: @answer_stamp_types } %>
-  </div>
+  <%= render partial: "stamps/stamp_buttons", locals: { stampable: question_answer, stamp_types: @answer_stamp_types } %>
 </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -9,9 +9,7 @@
     <p><%= @question.created_at.strftime('%Y/%m/%d') %></p>
   </div>
   <p class="mt-6"><%= @question.body %></p>
-  <div id="stamps_<%= "#{@question.id}" %>" >
-    <%= render partial: "stamps/stamp_buttons", locals: { stampable: @question, stamp_types: @question_stamp_types } %>
-  </div>
+  <%= render partial: "stamps/stamp_buttons", locals: { stampable: @question, stamp_types: @question_stamp_types } %>
 </div>
 
 <div class="justify-center items-center gap-y-8 p-4 mx-32 text-brown">

--- a/app/views/stamps/_stamp_buttons.html.erb
+++ b/app/views/stamps/_stamp_buttons.html.erb
@@ -1,4 +1,4 @@
-<div class="mt-4 flex gap-3">
+<div id="<%= dom_id(stampable, :stamps) %>" class="mt-4 flex gap-3">
   <% stamp_counts = stampable.stamps.group(:stamp_type_id).count %>
   <% user_stamp_ids = stampable.stamps.where(guest_id: cookies[:guest_id]).pluck(:stamp_type_id) %>
 

--- a/app/views/stamps/create.turbo_stream.erb
+++ b/app/views/stamps/create.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.update "stamps_#{@stamp.stampable.id}" do %>
+<%= turbo_stream.update dom_id(@stamp.stampable, :stamps) do %>
   <%= render partial: "stamps/stamp_buttons", locals: { stampable: @stamp.stampable, stamp_types: stamp_types(@stamp.stampable) } %>
 <% end %>

--- a/app/views/stamps/destroy.turbo_stream.erb
+++ b/app/views/stamps/destroy.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.update "stamps_#{@stamp.stampable.id}" do %>
+<%= turbo_stream.update dom_id(@stamp.stampable, :stamps) do %>
   <%= render partial: "stamps/stamp_buttons", locals: { stampable: @stamp.stampable, stamp_types: stamp_types(@stamp.stampable) } %>
 <% end %>


### PR DESCRIPTION
質問に対するスタンプに付与したidと、回答に対するスタンプに付与したidが同じものになっていたため
dom_idヘルパーを使用して、質問に対するスタンプと回答に対するスタンプそれぞれにユニークなidを付与しました。

closes #115 
